### PR TITLE
feat: creation of many utility methods with full test coverage (saveText, getVideoInfo, loadYOLOModel)

### DIFF
--- a/tests/utils/test_utils_io.py
+++ b/tests/utils/test_utils_io.py
@@ -2,24 +2,29 @@ import json
 
 import pytest
 
-from utils.io import loadJSON, saveJSON
+from utils.io import loadJSON, saveJSON, saveText
 
 
 @pytest.fixture
-def tmpPath(tmp_path):
+def jsonPath(tmp_path):
     return tmp_path / "test.json"
 
 
-def test_saveJSON_writesValidJSONToDisk(tmpPath):
-    saveJSON({"key": "value"}, tmpPath)
-    with open(tmpPath, "r") as f:
+@pytest.fixture
+def txtPath(tmp_path):
+    return tmp_path / "test.txt"
+
+
+def test_saveJSON_writesValidJSONToDisk(jsonPath):
+    saveJSON({"key": "value"}, jsonPath)
+    with open(jsonPath, "r") as f:
         data = json.load(f)
     assert data == {"key": "value"}
 
 
-def test_saveJSON_cleansTmpFileOnSuccess(tmpPath):
-    saveJSON({"key": "value"}, tmpPath)
-    assert not tmpPath.with_suffix(".tmp").exists()
+def test_saveJSON_cleansTmpFileOnSuccess(jsonPath):
+    saveJSON({"key": "value"}, jsonPath)
+    assert not jsonPath.with_suffix(".tmp").exists()
 
 
 def test_saveJSON_cleansTmpFileOnFailure(tmp_path):
@@ -34,7 +39,20 @@ def test_loadJSON_returnsNoneForNonexistentPath(tmp_path):
     assert result is None
 
 
-def test_loadJSON_roundTripsWithSaveJSON(tmpPath):
+def test_loadJSON_roundTripsWithSaveJSON(jsonPath):
     data = {"a": 1, "b": [1, 2, 3]}
-    saveJSON(data, tmpPath)
-    assert loadJSON(tmpPath) == data
+    saveJSON(data, jsonPath)
+    assert loadJSON(jsonPath) == data
+
+
+def test_saveText_writesCorrectContent(txtPath):
+    content = "testing, testing, 123..."
+    saveText(content, txtPath)
+    assert txtPath.read_text(encoding="utf-8") == content
+
+
+def test_saveText_cleansTmpFileOnFailure(tmp_path):
+    path = tmp_path / "fail.txt"
+    with pytest.raises(Exception):
+        saveText(None, path)
+    assert not path.with_suffix(".tmp").exists()

--- a/tests/utils/test_utils_video.py
+++ b/tests/utils/test_utils_video.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+
+import cv2
+import pytest
+
+from utils.video import getVideoInfo
+
+
+@patch("utils.video.cv2.VideoCapture")
+def test_getVideoInfo_returnsCorrectMetadata(mock_cap_class, tmp_path):
+    mockCap = MagicMock()
+    mockCap.isOpened.return_value = True
+
+    def mockGet(prop):
+        mapping = {
+            cv2.CAP_PROP_FRAME_COUNT: 100,
+            cv2.CAP_PROP_FPS: 30.0,
+            cv2.CAP_PROP_FRAME_WIDTH: 1920,
+            cv2.CAP_PROP_FRAME_HEIGHT: 1080,
+        }
+        return mapping.get(prop, 0)
+
+    mockCap.get.side_effect = mockGet
+    mock_cap_class.return_value = mockCap
+
+    result = getVideoInfo(tmp_path / "fake_video.mp4")
+
+    assert result["frame_count"] == 100
+    assert result["fps"] == 30.0
+    assert result["width"] == 1920
+    mockCap.release.assert_called_once()
+
+
+def test_getVideoInfo_raisesErrorOnInvalidPath(tmp_path):
+    with patch("utils.video.cv2.VideoCapture") as mockVC:
+        mockVC.return_value.isOpened.return_value = False
+        with pytest.raises(ValueError, match="Could not open video"):
+            getVideoInfo(tmp_path / "nonexistent.mp4")

--- a/tests/utils/test_utils_yolo.py
+++ b/tests/utils/test_utils_yolo.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from utils.yolo import loadYOLOModel
+
+
+@patch("utils.yolo.YOLO")
+def test_loadYOLOModel_callsYOLOWithCorrectPath(mock_yolo_class):
+    testPath = Path("models/test_model.pt")
+    loadYOLOModel(testPath)
+    mock_yolo_class.assert_called_once_with(str(testPath))
+
+
+def test_loadYOLOModel_returnsModelInstance():
+    with patch("utils.yolo.YOLO") as mockyolo:
+        mockInstance = MagicMock()
+        mockyolo.return_value = mockInstance
+
+        model = loadYOLOModel(Path("any.pt"))
+        assert model == mockInstance

--- a/utils/io.py
+++ b/utils/io.py
@@ -22,3 +22,16 @@ def loadJSON(path: Path) -> List[Dict] | Dict | None:
         return None
     with open(path, "r") as f:
         return json.load(f)
+
+
+def saveText(text: str, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmpPath = path.with_suffix(".tmp")
+    try:
+        with open(tmpPath, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmpPath, path)
+    except Exception as e:
+        if tmpPath.exists():
+            tmpPath.unlink()
+        raise e

--- a/utils/video.py
+++ b/utils/video.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import Any, Dict
+
+import cv2
+
+
+def getVideoInfo(path: Path) -> Dict[str, Any]:
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        raise ValueError(f"Could not open video: {path}")
+
+    info = {
+        "frame_count": int(cap.get(cv2.CAP_PROP_FRAME_COUNT)),
+        "fps": cap.get(cv2.CAP_PROP_FPS),
+        "width": int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
+        "height": int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+    }
+    cap.release()
+    return info

--- a/utils/yolo.py
+++ b/utils/yolo.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from ultralytics import YOLO
+
+
+def loadYOLOModel(modelPath: Path) -> YOLO:
+    return YOLO(str(modelPath))


### PR DESCRIPTION
Created many helpful utility methods in `utils/io.py`, `utils/video.py`, and `utils/yolo.py` with full test coverage.

## Changes
- **`utils/io.py`:** Added a `saveText` method, which saves a string object to a file. With atomic saving using `.tmp` files for safety against corrupt overwrites. Test coverage for method in `tests/utils/test_utils_io.py`.
- **`utils/video.py`:** New module with `getVideoInfo` method that returns the common metadata info for a video. Test coverage in `tests/utils/test_utils_video.py`.
- **`utils/yolo.py`:** New module for YOLO specific model utilities. Contains `loadYOLOModel` method for loading YOLO models. Test coverage in `tests/utils/test_utils_yolo.py`.