### PR TITLE
feat: implement CVAT XML export and CLI pre-annotation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This section serves as a living development log.
 
 ### Recently Completed
 <!-- Latest first. Maximum 10 items. Older entries belong in the git log. -->
+- `feat/cvat-preannotation-tooling`: created methods to convert raw model inference into CVAT compatible XML for ball (`ball/cvat.py`) and pose (`pose/cvat.py`) models with test coverage. Created CLI scripts for the pre-annotation pipeline for ball (`tools/preannotate_ball.py`) and pose (`tools/preannotate_pose.py) YOLO-based models.
+- `feat/common-utils-overhaul`: `saveText` method (in `utils/io.py`) for saving a string object to a file, `getVideoInfo` method (in `utils/video.py`) that returns the common video metadata info, `loadYOLOModel` method (in `utils/yolo.py`) for loading YOLO models. All new utility methods have full test coverage.
 - `feat/raw-inference-pipeline`: renamed test scripts from test_{module}.py to test_{library}_{module}.py to avoid collision errors. expanded pose constants to include more COCO keypoints (face, upper, all, body). Created YOLO compatible raw video inference methods for pose and ball models (this included the creation of `ball/inference.py`). Full test coverage for new methods.
 - `chore/docs-restructuring`: `/docs` directory created for any secondary documentation, `research.md` renamed to `RESEARCH.md` and relocated to inside `docs/`. Checked for any internal links that may be affected from restructure, found None.
 - `docs/update-readme-phases`: old "Project Phase" section of README replaced with new "[Pipeline Components](#pipeline-components)" section. Has a more clear direction as to what needs to be built for each component of the project. Updates to `research.md` to replace phase references and remove commitizen section.
@@ -80,8 +82,6 @@ This section serves as a living development log.
 - Update to `research.md` to include Inference Smoothing, ViTPose, RTMPose sections and updated the Ball Tracking section
 - YOLO pose model tested on high quality footage of shooting training drill - see `notebooks/pose/YOLO_pose_shooting_drills.ipynb`
 - Refactored relevant methods from `notebooks/pose/YOLO_candidate_comparison.ipynb` into the main repo with full test coverage (methods in: `pose/annotate.py`, `pose/inference.py`, `utils/io.py`, `utils/metrics.py`)
-- YOLO pose model comparison (YOLO11(m)(s)(l)(n) vs YOLO26m) - see `notebooks/pose/YOLO_candidate_comparison.ipynb`
-- `pose/visualise.py` - `drawKeypoints` with full test coverage
 
 ---
 
@@ -148,9 +148,7 @@ We follow the **Conventional Commits** standard using `Commitizen`. Every commit
 
 Created by [**WillEdgington**](https://github.com/WillEdgington)
 
-📧 [willedge037@gmail.com](mailto:willedge037@gmail.com)
-
-🔗 [LinkedIn](https://www.linkedin.com/in/williamedgington/)
+📧 [**willedge037@gmail.com**](mailto:willedge037@gmail.com) &nbsp;|&nbsp; 🔗 [**LinkedIn**](https://www.linkedin.com/in/williamedgington/)
 
 ## License
 

--- a/ball/config.py
+++ b/ball/config.py
@@ -2,4 +2,6 @@ from pathlib import Path
 
 from utils.config import SESSIONSDIR
 
+CONFTHRESHOLD = 0.25
+
 ANNOTATEDBALLVIDEOSDIR = SESSIONSDIR / Path("ball/annotated_videos")

--- a/ball/cvat.py
+++ b/ball/cvat.py
@@ -1,0 +1,75 @@
+from typing import Any, Dict, List
+from xml.dom.minidom import parseString
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from ball.config import CONFTHRESHOLD
+
+
+def _buildMeta(
+    root: Element,
+    totalFrames: int,
+    taskName: str,
+) -> None:
+    meta = SubElement(root, "meta")
+    task = SubElement(meta, "task")
+    SubElement(task, "id").text = "0"
+    SubElement(task, "name").text = taskName
+    SubElement(task, "size").text = str(totalFrames)
+    SubElement(task, "mode").text = "interpolation"
+    SubElement(task, "overlap").text = "0"
+    SubElement(task, "flipped").text = "False"
+    labels = SubElement(task, "labels")
+    label = SubElement(labels, "label")
+    SubElement(label, "name").text = "ball"
+    SubElement(label, "type").text = "bbox"
+
+
+def toCVATVideoXML(
+    frames: List[Dict[str, Any]],
+    totalFrames: int,
+    taskName: str = "ball-preannotation",
+    confThreshold: float = CONFTHRESHOLD,
+) -> str:
+    root = Element("annotations")
+    SubElement(root, "version").text = "1.1"
+    _buildMeta(root, totalFrames, taskName)
+
+    trackId = 0
+    for frameData in frames:
+        frameIdx = frameData.get("frame", None)
+        if frameIdx is None:
+            continue
+        for det in frameData.get("detections", []):
+            x1, y1, x2, y2 = det["box"]
+            track = SubElement(root, "track", id=str(trackId), source="auto")
+
+            SubElement(
+                track,
+                "box",
+                frame=str(frameIdx),
+                xtl=f"{x1:.2f}",
+                ytl=f"{y1:.2f}",
+                xbr=f"{x2:.2f}",
+                ybr=f"{y2:.2f}",
+                outside="0",
+                occluded="0" if det["conf"] >= confThreshold else "1",
+                keyframe="1",
+            )
+
+            # Mark track as outside on the very next frame
+            # to prevent CVAT interpolating forward
+            if frameIdx + 1 < totalFrames:
+                SubElement(
+                    track,
+                    "box",
+                    frame=str(frameIdx + 1),
+                    xtl=f"{x1:.2f}",
+                    ytl=f"{y1:.2f}",
+                    xbr=f"{x2:.2f}",
+                    ybr=f"{y2:.2f}",
+                    outside="1",
+                    occluded="0",
+                    keyframe="1",
+                )
+            trackId += 1
+    return parseString(tostring(root, encoding="unicode")).toprettyxml(indent="  ")

--- a/pose/cvat.py
+++ b/pose/cvat.py
@@ -1,0 +1,102 @@
+from typing import Any, Dict, List
+from xml.dom.minidom import parseString
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from pose.config import CONFTHRESHOLD
+from pose.constants import BODYKEYPOINTS
+
+
+def _buildMeta(
+    root: Element,
+    totalFrames: int,
+    taskName: str,
+    keypointIndexes: Dict[str, int] = BODYKEYPOINTS,
+) -> None:
+    meta = SubElement(root, "meta")
+    task = SubElement(meta, "task")
+    SubElement(task, "id").text = "0"
+    SubElement(task, "name").text = taskName
+    SubElement(task, "size").text = str(totalFrames)
+    SubElement(task, "mode").text = "interpolation"
+    SubElement(task, "overlap").text = "0"
+    SubElement(task, "flipped").text = "False"
+    labels = SubElement(task, "labels")
+
+    skelLabel = SubElement(labels, "label")
+    SubElement(skelLabel, "name").text = "person"
+    SubElement(skelLabel, "type").text = "skeleton"
+
+    sublabels = SubElement(skelLabel, "sublabels")
+    for kpName in keypointIndexes:
+        kplabel = SubElement(sublabels, "label")
+        SubElement(kplabel, "name").text = kpName
+        SubElement(kplabel, "type").text = "points"
+
+
+def toCVATVideoXML(
+    frames: List[Dict[str, Any]],
+    totalFrames: int,
+    keypointIndexes: Dict[str, int] = BODYKEYPOINTS,
+    taskName: str = "pose-preannotation",
+    confThreshold: float = CONFTHRESHOLD,
+) -> str:
+    root = Element("annotations")
+    SubElement(root, "version").text = "1.1"
+    _buildMeta(root, totalFrames, taskName, keypointIndexes)
+
+    trackId = 0
+    for frameData in frames:
+        frameIdx = frameData.get("frame", None)
+        if frameIdx is None:
+            continue
+        for det in frameData.get("detections", []):
+            x1, y1, x2, y2 = det["box"]
+            track = SubElement(
+                root, "track", id=str(trackId), label="person", source="auto"
+            )
+
+            skel = SubElement(
+                track,
+                "skeleton",
+                frame=str(frameIdx),
+                outside="0",
+                occluded="0",
+                keyframe="1",
+            )
+            SubElement(
+                skel,
+                "box",
+                xtl=f"{x1:.2f}",
+                ytl=f"{y1:.2f}",
+                xbr=f"{x2:.2f}",
+                ybr=f"{y2:.2f}",
+            )
+
+            for kpName in keypointIndexes:
+                kpData = det["keypoints"].get(kpName)  # [x, y, conf]
+                if kpData is None:
+                    continue
+                kx, ky, kconf = det["keypoints"][kpName]
+                SubElement(
+                    skel,
+                    "points",
+                    label=kpName,
+                    points=f"{kx:.2f},{ky:.2f}",
+                    outside="0",
+                    occluded="0" if kconf >= confThreshold else "1",
+                    keyframe="1",
+                )
+
+            # Mark track as outside on the very next frame
+            # to prevent CVAT interpolating forward
+            if frameIdx + 1 < totalFrames:
+                SubElement(
+                    track,
+                    "skeleton",
+                    frame=str(frameIdx + 1),
+                    outside="1",
+                    occluded="0",
+                    keyframe="1",
+                )
+            trackId += 1
+    return parseString(tostring(root, encoding="unicode")).toprettyxml(indent="  ")

--- a/tests/ball/test_ball_cvat.py
+++ b/tests/ball/test_ball_cvat.py
@@ -1,0 +1,53 @@
+from xml.etree.ElementTree import fromstring
+
+import pytest
+
+from ball.cvat import toCVATVideoXML
+
+
+@pytest.fixture
+def sampleBallData():
+    """one frame (frame=10), two balls (high confidence)"""
+    return [
+        {
+            "frame": 10,
+            "detections": [
+                {"box": [100, 200, 150, 250], "conf": 0.9},
+                {"box": [300, 400, 350, 450], "conf": 0.8},
+            ],
+        }
+    ]
+
+
+def test_toCVATVideoXML_incrementsTrackIds(sampleBallData):
+    xmlOut = toCVATVideoXML(sampleBallData, totalFrames=100)
+    root = fromstring(xmlOut)
+
+    tracks = root.findall("track")
+    assert len(tracks) == 2
+    assert tracks[0].get("id") == "0"
+    assert tracks[1].get("id") == "1"
+
+
+def test_toCVATVideoXML_preventsOutOfBoundsFrame(sampleBallData):
+    xmlOut = toCVATVideoXML(sampleBallData, totalFrames=11)  # frame = 10 + 1 is oob
+    root = fromstring(xmlOut)
+
+    boxes = root.findall(".//track[@id='0']/box")
+    assert len(boxes) == 1
+
+
+def test_toCVATVideoXML_handlesEmptyInput():
+    xmlOut = toCVATVideoXML([], totalFrames=10)
+    root = fromstring(xmlOut)
+
+    # Meta should exist, tracks should be empty
+    assert root.find(".//size").text == "10"
+    assert len(root.findall("track")) == 0
+
+
+def test_toCVATVideoXML_skipsMalformedFrame():
+    malformedData = [{"not_a_frame": 0}]
+    xmlOut = toCVATVideoXML(malformedData, 10)
+    root = fromstring(xmlOut)
+    assert len(root.findall("track")) == 0

--- a/tests/pose/test_pose_cvat.py
+++ b/tests/pose/test_pose_cvat.py
@@ -1,0 +1,110 @@
+from xml.etree.ElementTree import fromstring
+
+import pytest
+
+from pose.cvat import toCVATVideoXML
+
+
+@pytest.fixture
+def poseIndexes():
+    return {"left_ankle": 15, "right_ankle": 16}
+
+
+@pytest.fixture
+def samplePoseData():
+    return [
+        {
+            "frame": 0,
+            "detections": [
+                {
+                    "box": [10, 20, 30, 40],
+                    "keypoints": {
+                        "left_ankle": [105.0, 205.0, 0.9],
+                        "right_ankle": [110.0, 210.0, 0.1],  # Low confidence
+                    },
+                }
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+def samplePoseDataMissingAndExtraKeypoint():
+    return [
+        {
+            "frame": 0,
+            "detections": [
+                {
+                    "box": [10, 20, 30, 40],
+                    "keypoints": {
+                        "left_knee": [102.0, 195.0, 0.9],
+                        "left_ankle": [105.0, 205.0, 0.9],
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def test_toCVATVideoXML_fullCoverage_pose(samplePoseData, poseIndexes):
+    xmlOut = toCVATVideoXML(
+        samplePoseData, 10, keypointIndexes=poseIndexes, confThreshold=0.5
+    )
+    root = fromstring(xmlOut)
+
+    # Skeleton and Box existence
+    skeleton = root.find(".//skeleton")
+    assert skeleton is not None
+    assert skeleton.find("box") is not None
+
+    # Occlusion
+    pts = root.findall(".//points")
+    rightAnkle = next(p for p in pts if p.get("label") == "right_ankle")
+    assert rightAnkle.get("occluded") == "1"
+
+
+def test_toCVATVideoXML_handlesMissingAndExtraKeypoints(
+    samplePoseDataMissingAndExtraKeypoint, poseIndexes
+):
+    xmlOut = toCVATVideoXML(
+        samplePoseDataMissingAndExtraKeypoint,
+        totalFrames=10,
+        keypointIndexes=poseIndexes,
+    )
+    root = fromstring(xmlOut)
+    pointsTags = root.findall(".//points")
+    pointLabels = [p.get("label") for p in pointsTags]
+
+    # should contain left_ankle, but NOT right_ankle
+    assert "left_ankle" in pointLabels
+    assert "right_ankle" not in pointLabels
+
+    # left_knee should not be in point labels, even though it is in the pose data
+    assert "left_knee" not in pointLabels
+
+    # only expect one tag (left_ankle)
+    assert len(pointsTags) == 1
+
+
+def test_toCVATVideoXML_preventsOutOfBoundsFrame(samplePoseData):
+    xmlOut = toCVATVideoXML(samplePoseData, totalFrames=1)  # frame = 10 + 1 is oob
+    root = fromstring(xmlOut)
+
+    skeletons = root.findall(".//track[@id='0']/skeleton")
+    assert len(skeletons) == 1
+
+
+def test_toCVATVideoXML_handlesEmptyInput():
+    xmlOut = toCVATVideoXML([], totalFrames=10)
+    root = fromstring(xmlOut)
+
+    # Meta should exist, tracks should be empty
+    assert root.find(".//size").text == "10"
+    assert len(root.findall("track")) == 0
+
+
+def test_toCVATVideoXML_skipsMalformedFrame():
+    malformedData = [{"error": 0}]
+    xmlOut = toCVATVideoXML(malformedData, 10)
+    root = fromstring(xmlOut)
+    assert len(root.findall("track")) == 0

--- a/tools/preannotate_ball.py
+++ b/tools/preannotate_ball.py
@@ -1,0 +1,44 @@
+import argparse
+from pathlib import Path
+
+from ball.cvat import toCVATVideoXML
+from ball.inference import getRawVideoYOLOBall
+from utils.io import saveText
+from utils.video import getVideoInfo
+from utils.yolo import loadYOLOModel
+
+
+def main():
+    parser = argparse.ArguementParser(description="YOLO Ball to CVAT XML")
+    parser.add_arguement("--video", type=str, required=True, help="Path to input video")
+    parser.add_arguement(
+        "--model",
+        type=str,
+        default="models/yolo11n_ball/weights/best.pt",
+        help="Path to model",
+    )
+    parser.add_arguement(
+        "--output_dir",
+        type=str,
+        default="data/annotated/cvat_exports/ball",
+        help="Output Directory",
+    )
+    args = parser.parse_args()
+
+    videoPath = Path(args.video)
+    modelPath = Path(args.model)
+    outputPath = Path(args.output_dir) / f"{videoPath.stem}_ball.xml"
+
+    videoInfo = getVideoInfo(videoPath)
+    model = loadYOLOModel(modelPath)
+
+    raw = getRawVideoYOLOBall(model, videoPath)
+    xml = toCVATVideoXML(
+        frames=raw, totalFrames=videoInfo["frame_count"], taskName=videoPath.stem
+    )
+    saveText(xml, outputPath)
+    print(f"[Done] Exported: {outputPath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/preannotate_pose.py
+++ b/tools/preannotate_pose.py
@@ -1,0 +1,42 @@
+import argparse
+from pathlib import Path
+
+from pose.constants import BODYKEYPOINTS
+from pose.cvat import toCVATVideoXML
+from pose.inference import getRawVideoYOLOPose
+from utils.io import saveText
+from utils.video import getVideoInfo
+from utils.yolo import loadYOLOModel
+
+
+def main():
+    parser = argparse.ArgumentParser(description="YOLO Pose to CVAT XML")
+    parser.add_argument("--video", type=str, required=True, help="Path to input video")
+    parser.add_argument(
+        "--model", type=str, default="models/yolo11l-pose.pt", help="Path to model"
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="data/annotated/cvat_exports/pose",
+        help="Output Directory",
+    )
+    args = parser.parse_args()
+
+    videoPath = Path(args.video)
+    modelPath = Path(args.model)
+    outputPath = Path(args.output_dir) / f"{videoPath.stem}_pose.xml"
+
+    videoInfo = getVideoInfo(videoPath)
+    model = loadYOLOModel(modelPath)
+
+    raw = getRawVideoYOLOPose(model, videoPath, keypointIndexes=BODYKEYPOINTS)
+    xml = toCVATVideoXML(
+        frames=raw, totalFrames=videoInfo["frame_count"], taskName=videoPath.stem
+    )
+    saveText(xml, outputPath)
+    print(f"[Done] Exported: {outputPath}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Infrastructure and CLI utilities required to convert YOLO inference results into CVAT-compatible XML files. This enables a pre-annotation workflow, where model predictions are imported into CVAT to be refined by hand, in an effort to significantly reduce manual labelling time.

## Changes
- **Module Logic:**
    - `pose/cvat.py`: `toCVATVideoXML` method provides logic to convert keypoint detections into CVAT "Skeleton" tracks. Test coverage at `tests/pose/test_pose_cvat.py`
    - `ball/cvat.py`: `toCVATVideoXML` method provides logic to convert ball detections into CVAT "Bbox" tracks. Test coverage at `tests/pose/test_pose_cvat.py`
- **Infrastructure:**
    - Established `tools/` directory for standalone CLI entry points.
- **CLI Utilities:**
    - `tools/preannotate_pose.py`: Orchestrates pose inference and XML generation.
    - `tools/preannotate_ball.py`: Orchestrates ball inference and XML generation.
 
## Related Issues
- Closes #11 