### PR TITLE
feat: allow for batch pre-annotation processing in ball and pose CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ This section serves as a living development log.
 ### Current Focus
 - **Data labelling:** annotating existing shooting drill footage in CVAT. Ball bounding boxes and pose keypoints. This will define the ground truth format for future fine-tuning and evaluation.
 - **Data collection:** searching for and collecting vaired problem specific footage across different environments, angles, balls and people to address the current data distribution problem.
-- **Ball tracker refactor:** refactoring inference helpers and evaluation logic from `notebooks/ball/ball_detector_baseline_shooting_drills.ipynb` into the `ball/` module with full test coverage.
 - **Kick detection logic:** beginning design of the rule-based kick detector using existing pose output.
 
 ### Recently Completed
 <!-- Latest first. Maximum 10 items. Older entries belong in the git log. -->
+- `feat/preannotation-batch-processing`: `getAllVideoPaths` (`utils/video.py`) method for getting video paths from a directory, `batchCVATYOLOPosePreannotation` (`pose/preannotate.py`) method for batch CVAT pose pre-annotation, `batchCVATYOLOBallPreannotation` (`ball/preannotate.py`) method for batch CVAT ball pre-annotation. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts for batch processing.
 - `feat/cvat-preannotation-tooling`: created methods to convert raw model inference into CVAT compatible XML for ball (`ball/cvat.py`) and pose (`pose/cvat.py`) models with test coverage. Created CLI scripts for the pre-annotation pipeline for ball (`tools/preannotate_ball.py`) and pose (`tools/preannotate_pose.py) YOLO-based models.
 - `feat/common-utils-overhaul`: `saveText` method (in `utils/io.py`) for saving a string object to a file, `getVideoInfo` method (in `utils/video.py`) that returns the common video metadata info, `loadYOLOModel` method (in `utils/yolo.py`) for loading YOLO models. All new utility methods have full test coverage.
 - `feat/raw-inference-pipeline`: renamed test scripts from test_{module}.py to test_{library}_{module}.py to avoid collision errors. expanded pose constants to include more COCO keypoints (face, upper, all, body). Created YOLO compatible raw video inference methods for pose and ball models (this included the creation of `ball/inference.py`). Full test coverage for new methods.
@@ -81,7 +81,6 @@ This section serves as a living development log.
 - `chore/update-build-system`: Integrated GitHub Actions (CI), automated dependency management via pyproject.toml, and established a Branch & PR development protocol.
 - Update to `research.md` to include Inference Smoothing, ViTPose, RTMPose sections and updated the Ball Tracking section
 - YOLO pose model tested on high quality footage of shooting training drill - see `notebooks/pose/YOLO_pose_shooting_drills.ipynb`
-- Refactored relevant methods from `notebooks/pose/YOLO_candidate_comparison.ipynb` into the main repo with full test coverage (methods in: `pose/annotate.py`, `pose/inference.py`, `utils/io.py`, `utils/metrics.py`)
 
 ---
 

--- a/ball/config.py
+++ b/ball/config.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
-from utils.config import SESSIONSDIR
+from utils.config import CVATEXPORTSDIR, MODELSPATH, SESSIONSDIR
 
 CONFTHRESHOLD = 0.25
 
 ANNOTATEDBALLVIDEOSDIR = SESSIONSDIR / Path("ball/annotated_videos")
+CVATEXPORTSBALLDIR = CVATEXPORTSDIR / Path("ball")
+
+# current best is yolo11n finetuned on broadcast match footage from roboflow
+BESTBALLMODELPATH = MODELSPATH / Path("yolo11n_ball/weights/best.pt")

--- a/ball/preannotate.py
+++ b/ball/preannotate.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import List
+
+from ultralytics import YOLO
+
+from ball.config import CONFTHRESHOLD, CVATEXPORTSBALLDIR
+from ball.cvat import toCVATVideoXML
+from ball.inference import getRawVideoYOLOBall
+from utils.io import saveText
+from utils.video import getVideoInfo
+
+
+def batchCVATYOLOBallPreannotation(
+    model: YOLO,
+    videoPaths: List[Path],
+    outputDir: Path = CVATEXPORTSBALLDIR,
+    name: str = "YOLO-ball",
+    logging: bool = True,
+    overwrite: bool = False,
+) -> None:
+    for video in videoPaths:
+        if logging:
+            print(f"[Started] Processing: {video.name}")
+        try:
+            outputPath = outputDir / f"{video.stem}_ball.xml"
+            if outputPath.exists() and not overwrite:
+                if logging:
+                    print(f"[Skipped] Output path already exists: {outputPath}\n")
+                continue
+            videoInfo = getVideoInfo(video)
+            raw = getRawVideoYOLOBall(
+                model=model,
+                path=video,
+                name=name,
+                logging=logging,
+            )
+            xml = toCVATVideoXML(
+                frames=raw,
+                totalFrames=videoInfo["frame_count"],
+                taskName=video.stem,
+                confThreshold=CONFTHRESHOLD,
+            )
+            saveText(xml, outputPath)
+            if logging:
+                print(f"[Exported] CVAT pre-annotation XML: {outputPath.name}\n")
+        except Exception as e:
+            if logging:
+                print(f"[Failed] {video.name}: {e}")
+
+    if logging:
+        print("[Pre-annotation Complete]")

--- a/pose/config.py
+++ b/pose/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from utils.config import RAWTRAININGVIDEOSDIR, SESSIONSDIR
+from utils.config import CVATEXPORTSDIR, MODELSPATH, RAWTRAININGVIDEOSDIR, SESSIONSDIR
 
 CONFTHRESHOLD = 0.5
 
@@ -22,6 +22,10 @@ COMPSCOREWEIGHTS = {
 }
 
 ANNOTATEDPOSEVIDEOSDIR = SESSIONSDIR / Path("pose/annotated_videos")
+CVATEXPORTSPOSEDIR = CVATEXPORTSDIR / Path("pose")
+
+# current best model is standard version of yolo11l-pose model
+BESTPOSEMODELPATH = MODELSPATH / Path("yolo11l-pose.pt")
 
 __all__ = [
     "RAWTRAININGVIDEOSDIR",

--- a/pose/preannotate.py
+++ b/pose/preannotate.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from typing import Dict, List
+
+from ultralytics import YOLO
+
+from pose.config import CONFTHRESHOLD, CVATEXPORTSPOSEDIR
+from pose.constants import BODYKEYPOINTS
+from pose.cvat import toCVATVideoXML
+from pose.inference import getRawVideoYOLOPose
+from utils.io import saveText
+from utils.video import getVideoInfo
+
+
+def batchCVATYOLOPosePreannotation(
+    model: YOLO,
+    videoPaths: List[Path],
+    outputDir: Path = CVATEXPORTSPOSEDIR,
+    name: str = "YOLO-pose",
+    keypointIndexes: Dict[str, int] = BODYKEYPOINTS,
+    logging: bool = True,
+    overwrite: bool = False,
+) -> None:
+    for video in videoPaths:
+        if logging:
+            print(f"[Started] Processing: {video.name}")
+        try:
+            outputPath = outputDir / f"{video.stem}_pose.xml"
+            if outputPath.exists() and not overwrite:
+                if logging:
+                    print(f"[Skipped] Output path already exists: {outputPath}\n")
+                continue
+            videoInfo = getVideoInfo(video)
+            raw = getRawVideoYOLOPose(
+                model=model,
+                path=video,
+                keypointIndexes=keypointIndexes,
+                name=name,
+                logging=logging,
+            )
+            xml = toCVATVideoXML(
+                frames=raw,
+                totalFrames=videoInfo["frame_count"],
+                keypointIndexes=keypointIndexes,
+                taskName=video.stem,
+                confThreshold=CONFTHRESHOLD,
+            )
+            saveText(xml, outputPath)
+            if logging:
+                print(f"[Exported] CVAT pre-annotation XML: {outputPath.name}\n")
+        except Exception as e:
+            if logging:
+                print(f"[Failed] {video.name}: {e}")
+
+    if logging:
+        print("[Pre-annotation Complete]")

--- a/tests/ball/test_ball_preannotation.py
+++ b/tests/ball/test_ball_preannotation.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ball.preannotate import batchCVATYOLOBallPreannotation
+
+
+@pytest.fixture
+def mockDependencies():
+    with (
+        patch("ball.preannotate.getVideoInfo") as mInfo,
+        patch("ball.preannotate.getRawVideoYOLOBall") as mRaw,
+        patch("ball.preannotate.toCVATVideoXML") as mXml,
+        patch("ball.preannotate.saveText") as mSave,
+    ):
+
+        mInfo.return_value = {"frame_count": 100}
+        mRaw.return_value = [{"frame": 0, "detections": []}]
+        mXml.return_value = "<xml></xml>"
+
+        yield (mInfo, mRaw, mXml, mSave)
+
+
+def test_batchCVATYOLOBallPreannotation_skipsExistingFiles(tmp_path, mockDependencies):
+    mInfo, mRaw, mXml, mSave = mockDependencies
+
+    videoPath = tmp_path / "vid1.mp4"
+    xmlPath = tmp_path / "vid1_ball.xml"
+    xmlPath.touch()
+
+    batchCVATYOLOBallPreannotation(
+        model=MagicMock(),
+        videoPaths=[videoPath],
+        outputDir=tmp_path,
+        overwrite=False,
+        logging=False,
+    )
+
+    # Should have skipped processing
+    mRaw.assert_not_called()
+    mSave.assert_not_called()
+
+
+def test_batchCVATYOLOBallPreannotation_overwritesWhenRequested(
+    tmp_path, mockDependencies
+):
+    mInfo, mRaw, mXml, mSave = mockDependencies
+    videoPath = tmp_path / "vid1.mp4"
+    (tmp_path / "vid1_ball.xml").touch()
+
+    batchCVATYOLOBallPreannotation(
+        model=MagicMock(),
+        videoPaths=[videoPath],
+        outputDir=tmp_path,
+        overwrite=True,
+        logging=False,
+    )
+
+    # Should have processed despite the file existing
+    mRaw.assert_called_once()
+    mSave.assert_called_once()
+
+
+def test_batchCVATYOLOBallPreannotation_continuesOnIndividualFailure(
+    tmp_path, mockDependencies
+):
+    mInfo, mRaw, mXml, mSave = mockDependencies
+
+    vid1, vid2 = tmp_path / "fail.mp4", tmp_path / "pass.mp4"
+
+    # Force failure on the first video
+    mRaw.side_effect = [Exception("GPU OOM"), [{"frame": 0}]]
+
+    batchCVATYOLOBallPreannotation(
+        model=MagicMock(), videoPaths=[vid1, vid2], outputDir=tmp_path, logging=False
+    )
+
+    # Verify it attempted both and saved the successful one
+    assert mRaw.call_count == 2
+    mSave.assert_called_once()

--- a/tests/pose/test_pose_preannotate.py
+++ b/tests/pose/test_pose_preannotate.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pose.preannotate import batchCVATYOLOPosePreannotation
+
+
+@pytest.fixture
+def mockDependencies():
+    with (
+        patch("pose.preannotate.getVideoInfo") as mInfo,
+        patch("pose.preannotate.getRawVideoYOLOPose") as mRaw,
+        patch("pose.preannotate.toCVATVideoXML") as mXml,
+        patch("pose.preannotate.saveText") as mSave,
+    ):
+
+        mInfo.return_value = {"frame_count": 100}
+        mRaw.return_value = [{"frame": 0, "detections": []}]
+        mXml.return_value = "<xml></xml>"
+
+        yield (mInfo, mRaw, mXml, mSave)
+
+
+def test_batchCVATYOLOPosePreannotation_skipsExistingFiles(tmp_path, mockDependencies):
+    mInfo, mRaw, mXml, mSave = mockDependencies
+
+    videoPath = tmp_path / "vid1.mp4"
+    xmlPath = tmp_path / "vid1_pose.xml"
+    xmlPath.touch()
+
+    batchCVATYOLOPosePreannotation(
+        model=MagicMock(),
+        videoPaths=[videoPath],
+        outputDir=tmp_path,
+        overwrite=False,
+        logging=False,
+    )
+
+    # Should have skipped processing
+    mRaw.assert_not_called()
+    mSave.assert_not_called()
+
+
+def test_batchCVATYOLOPosePreannotation_overwritesWhenRequested(
+    tmp_path, mockDependencies
+):
+    mInfo, mRaw, mXml, mSave = mockDependencies
+    videoPath = tmp_path / "vid1.mp4"
+    (tmp_path / "vid1_pose.xml").touch()
+
+    batchCVATYOLOPosePreannotation(
+        model=MagicMock(),
+        videoPaths=[videoPath],
+        outputDir=tmp_path,
+        overwrite=True,
+        logging=False,
+    )
+
+    # Should have processed despite the file existing
+    mRaw.assert_called_once()
+    mSave.assert_called_once()
+
+
+def test_batchCVATYOLOPosePreannotation_continuesOnIndividualFailure(
+    tmp_path, mockDependencies
+):
+    mInfo, mRaw, mXml, mSave = mockDependencies
+
+    vid1, vid2 = tmp_path / "fail.mp4", tmp_path / "pass.mp4"
+
+    # Force failure on the first video
+    mRaw.side_effect = [Exception("GPU OOM"), [{"frame": 0}]]
+
+    batchCVATYOLOPosePreannotation(
+        model=MagicMock(), videoPaths=[vid1, vid2], outputDir=tmp_path, logging=False
+    )
+
+    # Verify it attempted both and saved the successful one
+    assert mRaw.call_count == 2
+    mSave.assert_called_once()

--- a/tests/utils/test_utils_video.py
+++ b/tests/utils/test_utils_video.py
@@ -1,9 +1,20 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import cv2
 import pytest
 
-from utils.video import getVideoInfo
+from utils.video import getAllVideoPaths, getVideoInfo
+
+
+@pytest.fixture
+def mockVideoDir(tmp_path):
+    """Creates a fake directory structure with various files."""
+    (tmp_path / "clip1.mp4").touch()
+    (tmp_path / "clip2.mov").touch()
+    (tmp_path / "notes.txt").touch()
+    (tmp_path / "test_clip3.mp4").touch()
+    return tmp_path
 
 
 @patch("utils.video.cv2.VideoCapture")
@@ -36,3 +47,26 @@ def test_getVideoInfo_raisesErrorOnInvalidPath(tmp_path):
         mockVC.return_value.isOpened.return_value = False
         with pytest.raises(ValueError, match="Could not open video"):
             getVideoInfo(tmp_path / "nonexistent.mp4")
+
+
+def test_getAllVideoPaths_findsAllVideos(mockVideoDir):
+    paths = getAllVideoPaths(mockVideoDir)
+    assert len(paths) == 3
+    assert all(p.suffix in [".mp4", ".mov"] for p in paths)
+
+
+def test_getAllVideoPaths_respectsPrefix(mockVideoDir):
+    paths = getAllVideoPaths(mockVideoDir, prefix="test_")
+    assert len(paths) == 1
+    assert paths[0].name == "test_clip3.mp4"
+
+
+def test_getAllVideoPaths_togglesSuffixes(mockVideoDir):
+    only_mp4 = getAllVideoPaths(mockVideoDir, mov=False)
+    assert all(p.suffix == ".mp4" for p in only_mp4)
+    assert len(only_mp4) == 2
+
+
+def test_getAllVideoPaths_raisesOnInvalidDir():
+    with pytest.raises(AssertionError):
+        getAllVideoPaths(Path("not/a/dir"))

--- a/tools/preannotate_ball.py
+++ b/tools/preannotate_ball.py
@@ -2,16 +2,20 @@ import argparse
 from pathlib import Path
 
 from ball.config import BESTBALLMODELPATH, CVATEXPORTSBALLDIR
-from ball.cvat import toCVATVideoXML
-from ball.inference import getRawVideoYOLOBall
-from utils.io import saveText
-from utils.video import getVideoInfo
+from ball.preannotate import batchCVATYOLOBallPreannotation
+from utils.config import RAWTRAININGVIDEOSDIR
+from utils.video import getAllVideoPaths
 from utils.yolo import loadYOLOModel
 
 
 def main():
     parser = argparse.ArgumentParser(description="YOLO Ball to CVAT XML")
-    parser.add_argument("--video", type=str, required=True, help="Path to input video")
+    parser.add_argument(
+        "--video",
+        type=str,
+        default=str(RAWTRAININGVIDEOSDIR),
+        help="Path to input video",
+    )
     parser.add_argument(
         "--model",
         type=str,
@@ -24,21 +28,36 @@ def main():
         default=str(CVATEXPORTSBALLDIR),
         help="Output Directory",
     )
+    parser.add_argument(
+        "--overwrite",
+        type=bool,
+        default=False,
+        help="Overwrite XML files of same name",
+    )
     args = parser.parse_args()
 
     videoPath = Path(args.video)
     modelPath = Path(args.model)
-    outputPath = Path(args.output_dir) / f"{videoPath.stem}_ball.xml"
+    outputDir = Path(args.output_dir)
+    overwrite = bool(args.overwrite)
 
-    videoInfo = getVideoInfo(videoPath)
-    model = loadYOLOModel(modelPath)
+    if videoPath.is_dir():
+        videoFiles = getAllVideoPaths(
+            videoDir=videoPath,
+        )
+        if not videoFiles:
+            print(f"[Error] No .mp4 or .mov files found in {videoPath}")
+            return
+    else:
+        videoFiles = [videoPath]
 
-    raw = getRawVideoYOLOBall(model, videoPath)
-    xml = toCVATVideoXML(
-        frames=raw, totalFrames=videoInfo["frame_count"], taskName=videoPath.stem
+    model = loadYOLOModel(modelPath=modelPath)
+    batchCVATYOLOBallPreannotation(
+        model=model,
+        videoPaths=videoFiles,
+        outputDir=outputDir,
+        overwrite=overwrite,
     )
-    saveText(xml, outputPath)
-    print(f"[Done] Exported: {outputPath}")
 
 
 if __name__ == "__main__":

--- a/tools/preannotate_ball.py
+++ b/tools/preannotate_ball.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 
+from ball.config import BESTBALLMODELPATH, CVATEXPORTSBALLDIR
 from ball.cvat import toCVATVideoXML
 from ball.inference import getRawVideoYOLOBall
 from utils.io import saveText
@@ -14,13 +15,13 @@ def main():
     parser.add_arguement(
         "--model",
         type=str,
-        default="models/yolo11n_ball/weights/best.pt",
+        default=str(BESTBALLMODELPATH),
         help="Path to model",
     )
     parser.add_arguement(
         "--output_dir",
         type=str,
-        default="data/annotated/cvat_exports/ball",
+        default=str(CVATEXPORTSBALLDIR),
         help="Output Directory",
     )
     args = parser.parse_args()

--- a/tools/preannotate_ball.py
+++ b/tools/preannotate_ball.py
@@ -10,15 +10,15 @@ from utils.yolo import loadYOLOModel
 
 
 def main():
-    parser = argparse.ArguementParser(description="YOLO Ball to CVAT XML")
-    parser.add_arguement("--video", type=str, required=True, help="Path to input video")
-    parser.add_arguement(
+    parser = argparse.ArgumentParser(description="YOLO Ball to CVAT XML")
+    parser.add_argument("--video", type=str, required=True, help="Path to input video")
+    parser.add_argument(
         "--model",
         type=str,
         default=str(BESTBALLMODELPATH),
         help="Path to model",
     )
-    parser.add_arguement(
+    parser.add_argument(
         "--output_dir",
         type=str,
         default=str(CVATEXPORTSBALLDIR),

--- a/tools/preannotate_pose.py
+++ b/tools/preannotate_pose.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 
+from pose.config import BESTPOSEMODELPATH, CVATEXPORTSPOSEDIR
 from pose.constants import BODYKEYPOINTS
 from pose.cvat import toCVATVideoXML
 from pose.inference import getRawVideoYOLOPose
@@ -13,12 +14,12 @@ def main():
     parser = argparse.ArgumentParser(description="YOLO Pose to CVAT XML")
     parser.add_argument("--video", type=str, required=True, help="Path to input video")
     parser.add_argument(
-        "--model", type=str, default="models/yolo11l-pose.pt", help="Path to model"
+        "--model", type=str, default=str(BESTPOSEMODELPATH), help="Path to model"
     )
     parser.add_argument(
         "--output_dir",
         type=str,
-        default="data/annotated/cvat_exports/pose",
+        default=str(CVATEXPORTSPOSEDIR),
         help="Output Directory",
     )
     args = parser.parse_args()

--- a/tools/preannotate_pose.py
+++ b/tools/preannotate_pose.py
@@ -3,16 +3,20 @@ from pathlib import Path
 
 from pose.config import BESTPOSEMODELPATH, CVATEXPORTSPOSEDIR
 from pose.constants import BODYKEYPOINTS
-from pose.cvat import toCVATVideoXML
-from pose.inference import getRawVideoYOLOPose
-from utils.io import saveText
-from utils.video import getVideoInfo
+from pose.preannotate import batchCVATYOLOPosePreannotation
+from utils.config import RAWTRAININGVIDEOSDIR
+from utils.video import getAllVideoPaths
 from utils.yolo import loadYOLOModel
 
 
 def main():
     parser = argparse.ArgumentParser(description="YOLO Pose to CVAT XML")
-    parser.add_argument("--video", type=str, required=True, help="Path to input video")
+    parser.add_argument(
+        "--video",
+        type=str,
+        default=str(RAWTRAININGVIDEOSDIR),
+        help="Path to input video",
+    )
     parser.add_argument(
         "--model", type=str, default=str(BESTPOSEMODELPATH), help="Path to model"
     )
@@ -22,21 +26,37 @@ def main():
         default=str(CVATEXPORTSPOSEDIR),
         help="Output Directory",
     )
+    parser.add_argument(
+        "--overwrite",
+        type=bool,
+        default=False,
+        help="Overwrite XML files of same name",
+    )
     args = parser.parse_args()
 
     videoPath = Path(args.video)
     modelPath = Path(args.model)
-    outputPath = Path(args.output_dir) / f"{videoPath.stem}_pose.xml"
+    outputDir = Path(args.output_dir)
+    overwrite = bool(args.overwrite)
 
-    videoInfo = getVideoInfo(videoPath)
-    model = loadYOLOModel(modelPath)
+    if videoPath.is_dir():
+        videoFiles = getAllVideoPaths(
+            videoDir=videoPath,
+        )
+        if not videoFiles:
+            print(f"[Error] No .mp4 or .mov files found in {videoPath}")
+            return
+    else:
+        videoFiles = [videoPath]
 
-    raw = getRawVideoYOLOPose(model, videoPath, keypointIndexes=BODYKEYPOINTS)
-    xml = toCVATVideoXML(
-        frames=raw, totalFrames=videoInfo["frame_count"], taskName=videoPath.stem
+    model = loadYOLOModel(modelPath=modelPath)
+    batchCVATYOLOPosePreannotation(
+        model=model,
+        videoPaths=videoFiles,
+        outputDir=outputDir,
+        keypointIndexes=BODYKEYPOINTS,
+        overwrite=overwrite,
     )
-    saveText(xml, outputPath)
-    print(f"[Done] Exported: {outputPath}")
 
 
 if __name__ == "__main__":

--- a/utils/config.py
+++ b/utils/config.py
@@ -2,3 +2,5 @@ from pathlib import Path
 
 RAWTRAININGVIDEOSDIR = Path("data/raw/training_drills_videos")
 SESSIONSDIR = Path("data/sessions")
+CVATEXPORTSDIR = Path("data/annotated/cvat_exports")
+MODELSPATH = Path("models")

--- a/utils/video.py
+++ b/utils/video.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import cv2
 
@@ -17,3 +17,22 @@ def getVideoInfo(path: Path) -> Dict[str, Any]:
     }
     cap.release()
     return info
+
+
+def getAllVideoPaths(
+    videoDir: Path, mp4: bool = True, mov: bool = True, prefix: str | None = None
+) -> List[Path]:
+    assert mp4 or mov, "mp4 or mov must be set to True"
+    assert videoDir.is_dir(), "videoDir must be a valid directory"
+    suffixes = []
+    if mp4:
+        suffixes.append("*.mp4")
+    if mov:
+        suffixes.append("*.mov")
+
+    videoPaths = []
+    for suf in suffixes:
+        videoPaths.extend(videoDir.glob(suf))
+    if prefix is not None:
+        videoPaths = [p for p in videoPaths if p.stem.startswith(prefix)]
+    return videoPaths


### PR DESCRIPTION
Refactors the pre-annotation tooling to support directory-level processing. By shifting orchestration logic from the CLI scripts into dedicated `preannotate.py` modules, the system now supports processing entire directories of footage in a single execution. This update significantly improves efficiency by loading models only once per batch and providing robust error isolation.

## Changes
- **Module Logic:**
    - `pose/preannotate.py`: Implemented `batchCVATYOLOPosePreannotation` for orchestrated batch processing of pose data. Test coverage at `tests/pose/test_pose_preannotate.py`.
    - `ball/preannotate.py`: Implemented `batchCVATYOLOBallPreannotation` for orchestrated batch processing of ball data. Test coverage at `tests/ball/test_ball_preannotate.py`.
    - `utils/video.py`: Added `getAllVideoPaths` to handle directory scanning for `.mp4` and `.mov` files with optional prefix filtering. Test coverage at `tests/utils/test_utils_video.py`.
- **Infrastructure & Config:**
    - Centralised path management by adding `BESTPOSEMODELPATH`, `BESTBALLMODELPATH`, and raw video directory defaults to `config.py` modules.
    - Improved `argparse` handling in CLI tools to leverage these new config constants.
- **CLI Utilities:**
    - `tools/preannotate_pose.py`: Refactored to support both single video paths and directory inputs. Added `--overwrite` flag support.
    - `tools/preannotate_ball.py`: Refactored to support both single video paths and directory inputs. Added `--overwrite` flag support. Fixed syntax errors for the misspelling of "argument".

## Related Issues
- Closes #14 