### PR TITLE
feat: allow for --root input argument in pre-annotation ball and pose CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This section serves as a living development log.
 
 ### Recently Completed
 <!-- Latest first. Maximum 10 items. Older entries belong in the git log. -->
+- `feat/preannotation-CLI-root-arg`: created `resolvePath` (`utils/io.py`) method for resolving a path from a given `root` and `path` input. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts with addition of `--root` input argument to allow for user to input a custom project root directory rather than the default assumption (`.`).
 - `feat/preannotation-batch-processing`: `getAllVideoPaths` (`utils/video.py`) method for getting video paths from a directory, `batchCVATYOLOPosePreannotation` (`pose/preannotate.py`) method for batch CVAT pose pre-annotation, `batchCVATYOLOBallPreannotation` (`ball/preannotate.py`) method for batch CVAT ball pre-annotation. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts for batch processing.
 - `feat/cvat-preannotation-tooling`: created methods to convert raw model inference into CVAT compatible XML for ball (`ball/cvat.py`) and pose (`pose/cvat.py`) models with test coverage. Created CLI scripts for the pre-annotation pipeline for ball (`tools/preannotate_ball.py`) and pose (`tools/preannotate_pose.py) YOLO-based models.
 - `feat/common-utils-overhaul`: `saveText` method (in `utils/io.py`) for saving a string object to a file, `getVideoInfo` method (in `utils/video.py`) that returns the common video metadata info, `loadYOLOModel` method (in `utils/yolo.py`) for loading YOLO models. All new utility methods have full test coverage.
@@ -80,7 +81,6 @@ This section serves as a living development log.
 - `experiment/ball-detection-baseline`: evaluated a fine-tuned `yolo11n` and pre-trained `footandball` model for ball tracking on high quality shooting drill footage. Concluded that the fine-tuned `yolo11n` was the better baseline model.
 - `chore/update-build-system`: Integrated GitHub Actions (CI), automated dependency management via pyproject.toml, and established a Branch & PR development protocol.
 - Update to `research.md` to include Inference Smoothing, ViTPose, RTMPose sections and updated the Ball Tracking section
-- YOLO pose model tested on high quality footage of shooting training drill - see `notebooks/pose/YOLO_pose_shooting_drills.ipynb`
 
 ---
 

--- a/tests/utils/test_utils_io.py
+++ b/tests/utils/test_utils_io.py
@@ -1,8 +1,10 @@
 import json
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from utils.io import loadJSON, saveJSON, saveText
+from utils.io import loadJSON, resolvePath, saveJSON, saveText
 
 
 @pytest.fixture
@@ -56,3 +58,24 @@ def test_saveText_cleansTmpFileOnFailure(tmp_path):
     with pytest.raises(Exception):
         saveText(None, path)
     assert not path.with_suffix(".tmp").exists()
+
+
+def test_resolvePath_rootPrependsToPath():
+    path = "fake_dir"
+    root = "fake_root/football-kick-tracker"
+    assert Path(root) / Path(path) == resolvePath(root, path)
+    assert Path(root) / Path(path) == resolvePath(Path(root), Path(path))
+
+
+def test_resolvePath_emptyRootReturnsInputPath():
+    path = Path("fake_dir")
+    assert path == resolvePath("", path)
+    assert path == resolvePath(".", path)
+
+
+def test_resolvePath_absoluteInputPathDoesNotPrependRoot():
+    path = Path("absolute_path/football-kick-tracker")
+    root = Path("ignored_root")
+    with patch("utils.io.Path.is_absolute") as mockAbsolute:
+        mockAbsolute.return_value = True
+        assert path == resolvePath(root, path)

--- a/tools/preannotate_ball.py
+++ b/tools/preannotate_ball.py
@@ -4,12 +4,19 @@ from pathlib import Path
 from ball.config import BESTBALLMODELPATH, CVATEXPORTSBALLDIR
 from ball.preannotate import batchCVATYOLOBallPreannotation
 from utils.config import RAWTRAININGVIDEOSDIR
+from utils.io import resolvePath
 from utils.video import getAllVideoPaths
 from utils.yolo import loadYOLOModel
 
 
 def main():
     parser = argparse.ArgumentParser(description="YOLO Ball to CVAT XML")
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=".",
+        help="Project root directory",
+    )
     parser.add_argument(
         "--video",
         type=str,
@@ -26,20 +33,20 @@ def main():
         "--output_dir",
         type=str,
         default=str(CVATEXPORTSBALLDIR),
-        help="Output Directory",
+        help="Output directory",
     )
     parser.add_argument(
         "--overwrite",
-        type=bool,
-        default=False,
+        action="store_true",
         help="Overwrite XML files of same name",
     )
     args = parser.parse_args()
 
-    videoPath = Path(args.video)
-    modelPath = Path(args.model)
-    outputDir = Path(args.output_dir)
-    overwrite = bool(args.overwrite)
+    root = Path(args.root)
+    videoPath = resolvePath(root, args.video)
+    modelPath = resolvePath(root, args.model)
+    outputDir = resolvePath(root, args.output_dir)
+    overwrite = args.overwrite
 
     if videoPath.is_dir():
         videoFiles = getAllVideoPaths(

--- a/tools/preannotate_pose.py
+++ b/tools/preannotate_pose.py
@@ -5,6 +5,7 @@ from pose.config import BESTPOSEMODELPATH, CVATEXPORTSPOSEDIR
 from pose.constants import BODYKEYPOINTS
 from pose.preannotate import batchCVATYOLOPosePreannotation
 from utils.config import RAWTRAININGVIDEOSDIR
+from utils.io import resolvePath
 from utils.video import getAllVideoPaths
 from utils.yolo import loadYOLOModel
 
@@ -12,32 +13,41 @@ from utils.yolo import loadYOLOModel
 def main():
     parser = argparse.ArgumentParser(description="YOLO Pose to CVAT XML")
     parser.add_argument(
+        "--root",
+        type=str,
+        default=".",
+        help="Project root directory",
+    )
+    parser.add_argument(
         "--video",
         type=str,
         default=str(RAWTRAININGVIDEOSDIR),
         help="Path to input video",
     )
     parser.add_argument(
-        "--model", type=str, default=str(BESTPOSEMODELPATH), help="Path to model"
+        "--model",
+        type=str,
+        default=str(BESTPOSEMODELPATH),
+        help="Path to model",
     )
     parser.add_argument(
         "--output_dir",
         type=str,
         default=str(CVATEXPORTSPOSEDIR),
-        help="Output Directory",
+        help="Output directory",
     )
     parser.add_argument(
         "--overwrite",
-        type=bool,
-        default=False,
+        action="store_true",
         help="Overwrite XML files of same name",
     )
     args = parser.parse_args()
 
-    videoPath = Path(args.video)
-    modelPath = Path(args.model)
-    outputDir = Path(args.output_dir)
-    overwrite = bool(args.overwrite)
+    root = Path(args.root)
+    videoPath = resolvePath(root, args.video)
+    modelPath = resolvePath(root, args.model)
+    outputDir = resolvePath(root, args.output_dir)
+    overwrite = args.overwrite
 
     if videoPath.is_dir():
         videoFiles = getAllVideoPaths(

--- a/utils/io.py
+++ b/utils/io.py
@@ -35,3 +35,12 @@ def saveText(text: str, path: Path) -> None:
         if tmpPath.exists():
             tmpPath.unlink()
         raise e
+
+
+def resolvePath(root: str | Path, path: str | Path) -> Path:
+    path = path if isinstance(path, Path) else Path(path)
+    if path.is_absolute() or (isinstance(root, str) and root in {"", "."}):
+        return path
+    root = root if isinstance(root, Path) else Path(root)
+
+    return root / path


### PR DESCRIPTION
Introduces a `--root` argument to the pre-annotation CLI tools to support flexible project root resolution. This allows the scripts to correctly locate models, data, and export directories when the repository is mirrored or mounted in a subdirectory (e.g., Google Drive/Colab), while maintaining standard behaviour for local execution.

## Changes
- **Module Logic:**
    - `utils/io.py`: Created `resolvePath` method to handle logic for prepending a root directory to relative paths while respecting absolute paths.
    - **Testing:** Test coverage for `resolvePath` implemented in `tests/utils/test_utils_io.py`.
- **CLI Utilities:**
    - `tools/preannotate_pose.py`: Added `--root` argument and refactored path resolution for video, model, and output directories.
    - `tools/preannotate_ball.py`: Added `--root` argument and refactored path resolution for video, model, and output directories.
    - Updated both scripts to use `action="store_true"` for the `--overwrite` argument to resolve boolean parsing issues.

## Related Issues
- Closes #17 