### PR TITLE
experiment: add runner notebooks for pose and ball CVAT pre-annotation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This section serves as a living development log.
 
 ### Recently Completed
 <!-- Latest first. Maximum 10 items. Older entries belong in the git log. -->
+- `experiment/preannotation-tool-notebooks`: created `notebooks/tools/preannotate_pose_script.ipynb`, `notebooks/tools/preannotate_ball_script.ipynb` notebooks to provide a way to run `tools/preannotate_pose.py`, `tools/preannotate_ball.py` on a non-local kernel (i.e. Colab GPU).
 - `feat/preannotation-CLI-root-arg`: created `resolvePath` (`utils/io.py`) method for resolving a path from a given `root` and `path` input. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts with addition of `--root` input argument to allow for user to input a custom project root directory rather than the default assumption (`.`).
 - `feat/preannotation-batch-processing`: `getAllVideoPaths` (`utils/video.py`) method for getting video paths from a directory, `batchCVATYOLOPosePreannotation` (`pose/preannotate.py`) method for batch CVAT pose pre-annotation, `batchCVATYOLOBallPreannotation` (`ball/preannotate.py`) method for batch CVAT ball pre-annotation. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts for batch processing.
 - `feat/cvat-preannotation-tooling`: created methods to convert raw model inference into CVAT compatible XML for ball (`ball/cvat.py`) and pose (`pose/cvat.py`) models with test coverage. Created CLI scripts for the pre-annotation pipeline for ball (`tools/preannotate_ball.py`) and pose (`tools/preannotate_pose.py) YOLO-based models.
@@ -80,7 +81,6 @@ This section serves as a living development log.
 - `docs/update-readme-phases`: old "Project Phase" section of README replaced with new "[Pipeline Components](#pipeline-components)" section. Has a more clear direction as to what needs to be built for each component of the project. Updates to `research.md` to replace phase references and remove commitizen section.
 - `experiment/ball-detection-baseline`: evaluated a fine-tuned `yolo11n` and pre-trained `footandball` model for ball tracking on high quality shooting drill footage. Concluded that the fine-tuned `yolo11n` was the better baseline model.
 - `chore/update-build-system`: Integrated GitHub Actions (CI), automated dependency management via pyproject.toml, and established a Branch & PR development protocol.
-- Update to `research.md` to include Inference Smoothing, ViTPose, RTMPose sections and updated the Ball Tracking section
 
 ---
 

--- a/notebooks/tools/preannotate_ball_script.ipynb
+++ b/notebooks/tools/preannotate_ball_script.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1f58117a",
+   "metadata": {},
+   "source": [
+    "# CVAT Pre-annotation: Ball Detection\n",
+    "\n",
+    "This notebook provides a way to run `/tools/preannotation_ball.py` CLI script on a non-local GPU (like Colab's GPU)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74e362b7",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Adjust the parameters in the code cell below to fit your needs. path configurations that are defined as an empty string (`\"\"`) will utilise the default argument value defined in `tools/preannotate_ball.py`.\n",
+    "\n",
+    "### Configurables Explained\n",
+    "|Variable|Description|\n",
+    "|---|---|\n",
+    "|`DRIVEREPODIR`|This is the path of the common parent for all relative paths below. Current configuration points to a mirrored Google Drive repo. If left empty (`\"\"`), no root path will be prepended to the relative paths below.|\n",
+    "|`INPUTPATH`|Path to a single video file (`.mp4`, `.mov`) or a directory of multiple videos. If left empty (`\"\"`), it defaults to the relative path defined by `utils.config.RAWTRAININGVIDEOSDIR`.|\n",
+    "|`MODELPATH`|Path to a `.pt` YOLO model file. If left empty (`\"\"`), it defaults to the relative path defined by `ball.config.BESTBALLMODELPATH`.|\n",
+    "|`OUTPUTPATH`|Path to the export destination where the generated CVAT `.xml` files will be saved. If left empty (`\"\"`), it defaults to the relative path defined by `ball.config.CVATEXPORTSBALLDIR`|\n",
+    "|`OVERWRITE`|Safety toggle `bool`. If `True`, the script replaces existing `.xml` of the same output name with newly generated `.xml` in the `OUTPUTPATH`. If `False`, the script skips already-processed videos (recommended for long batches for progress persistence on interrupted runs).|"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66eedc33",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# mirrored repo in Google Drive for models and data\n",
+    "DRIVEREPODIR: str = \"/content/drive/MyDrive/football-kick-tracker\"\n",
+    "\n",
+    "INPUTPATH: str = \"\"\n",
+    "MODELPATH: str = \"\"\n",
+    "OUTPUTPATH: str = \"\"\n",
+    "OVERWRITE: bool = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b56ae3b",
+   "metadata": {},
+   "source": [
+    "## Setup Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04ae90f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "from IPython.display import clear_output\n",
+    "\n",
+    "REPOURL = \"https://github.com/WillEdgington/football-kick-tracker.git\"\n",
+    "REPODIR = \"football-kick-tracker\"\n",
+    "\n",
+    "if not os.path.exists(REPODIR):\n",
+    "    !git clone {REPOURL}\n",
+    "else:\n",
+    "    !git -C {REPODIR} pull origin main\n",
+    "\n",
+    "%pip install -e {REPODIR} -q\n",
+    "\n",
+    "projectRoot = os.path.join(os.getcwd(), REPODIR)\n",
+    "if projectRoot not in sys.path:\n",
+    "    sys.path.insert(0, projectRoot)\n",
+    "\n",
+    "clear_output()\n",
+    "\n",
+    "print(\"Environment Setup Complete.\")\n",
+    "print(f\"Project Root added to sys.path: {projectRoot}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d5e70cf",
+   "metadata": {},
+   "source": [
+    "## Mount Google Drive\n",
+    "\n",
+    "Run this cell to mount your Google Drive (if `DRIVEREPODIR` points to a mirrored repo for data and models that you may have in your Google Drive)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55311e42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b774d4",
+   "metadata": {},
+   "source": [
+    "## Run `tools/preannotate_pose.py` CLI script"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6925fe43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputPathFlag = f' --video \"{INPUTPATH}\"' if INPUTPATH != \"\" else ''\n",
+    "modelPathFlag = f' --model \"{MODELPATH}\"' if MODELPATH != \"\" else ''\n",
+    "outputPathFlag = f' --output_dir \"{OUTPUTPATH}\"' if OUTPUTPATH != \"\" else ''\n",
+    "overwriteFlag = ' --overwrite' if OVERWRITE else ''\n",
+    "\n",
+    "!python {REPODIR}/tools/preannotate_ball.py \\\n",
+    "    --root \"{DRIVEREPODIR}\" \\\n",
+    "    {inputPathFlag}{modelPathFlag}{outputPathFlag}{overwriteFlag}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tools/preannotate_pose_script.ipynb
+++ b/notebooks/tools/preannotate_pose_script.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1f58117a",
+   "metadata": {},
+   "source": [
+    "# CVAT Pre-annotation: Pose Estimation\n",
+    "\n",
+    "This notebook provides a way to run `/tools/preannotation_pose.py` CLI script on a non-local GPU (like Colab's GPU)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74e362b7",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Adjust the parameters in the code cell below to fit your needs. path configurations that are defined as an empty string (`\"\"`) will utilise the default argument value defined in `tools/preannotate_pose.py`.\n",
+    "\n",
+    "### Configurables Explained\n",
+    "|Variable|Description|\n",
+    "|---|---|\n",
+    "|`DRIVEREPODIR`|This is the path of the common parent for all relative paths below. Current configuration points to a mirrored Google Drive repo. If left empty (`\"\"`), no root path will be prepended to the relative paths below.|\n",
+    "|`INPUTPATH`|Path to a single video file (`.mp4`, `.mov`) or a directory of multiple videos. If left empty (`\"\"`), it defaults to the relative path defined by `utils.config.RAWTRAININGVIDEOSDIR`.|\n",
+    "|`MODELPATH`|Path to a `.pt` YOLO model file. If left empty (`\"\"`), it defaults to the relative path defined by `pose.config.BESTPOSEMODELPATH`.|\n",
+    "|`OUTPUTPATH`|Path to the export destination where the generated CVAT `.xml` files will be saved. If left empty (`\"\"`), it defaults to the relative path defined by `pose.config.CVATEXPORTSPOSEDIR`|\n",
+    "|`OVERWRITE`|Safety toggle `bool`. If `True`, the script replaces existing `.xml` of the same output name with newly generated `.xml` in the `OUTPUTPATH`. If `False`, the script skips already-processed videos (recommended for long batches for progress persistence on interrupted runs).|"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66eedc33",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# mirrored repo in Google Drive for models and data\n",
+    "DRIVEREPODIR: str = \"/content/drive/MyDrive/football-kick-tracker\"\n",
+    "\n",
+    "INPUTPATH: str = \"\"\n",
+    "MODELPATH: str = \"\"\n",
+    "OUTPUTPATH: str = \"\"\n",
+    "OVERWRITE: bool = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b56ae3b",
+   "metadata": {},
+   "source": [
+    "## Setup Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04ae90f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "from IPython.display import clear_output\n",
+    "\n",
+    "REPOURL = \"https://github.com/WillEdgington/football-kick-tracker.git\"\n",
+    "REPODIR = \"football-kick-tracker\"\n",
+    "\n",
+    "if not os.path.exists(REPODIR):\n",
+    "    !git clone {REPOURL}\n",
+    "else:\n",
+    "    !git -C {REPODIR} pull origin main\n",
+    "\n",
+    "%pip install -e {REPODIR} -q\n",
+    "\n",
+    "projectRoot = os.path.join(os.getcwd(), REPODIR)\n",
+    "if projectRoot not in sys.path:\n",
+    "    sys.path.insert(0, projectRoot)\n",
+    "\n",
+    "clear_output()\n",
+    "\n",
+    "print(\"Environment Setup Complete.\")\n",
+    "print(f\"Project Root added to sys.path: {projectRoot}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d5e70cf",
+   "metadata": {},
+   "source": [
+    "## Mount Google Drive\n",
+    "\n",
+    "Run this cell to mount your Google Drive (if `DRIVEREPODIR` points to a mirrored repo for data and models that you may have in your Google Drive)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55311e42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b774d4",
+   "metadata": {},
+   "source": [
+    "## Run `tools/preannotate_pose.py` CLI script"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6925fe43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputPathFlag = f' --video \"{INPUTPATH}\"' if INPUTPATH != \"\" else ''\n",
+    "modelPathFlag = f' --model \"{MODELPATH}\"' if MODELPATH != \"\" else ''\n",
+    "outputPathFlag = f' --output_dir \"{OUTPUTPATH}\"' if OUTPUTPATH != \"\" else ''\n",
+    "overwriteFlag = ' --overwrite' if OVERWRITE else ''\n",
+    "\n",
+    "!python {REPODIR}/tools/preannotate_pose.py \\\n",
+    "    --root \"{DRIVEREPODIR}\" \\\n",
+    "    {inputPathFlag}{modelPathFlag}{outputPathFlag}{overwriteFlag}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Introduces dedicated runner notebooks to facilitate executing pre-annotation CLI scripts within a Google Colab environment. These notebooks streamline the batch processing workflow by automating environment setup, Google Drive mounting, and providing a clear, configurable interface for script parameters.

## Changes
- `notebooks/tools/preannotate_pose_script.ipynb`: Configurable runner for the pose estimation pre-annotation pipeline (`tools/preannotate_pose.py`).  Allows for use on a non-local kernel (i.e. Colab GPU).
- `notebooks/tools/preannotate_ball_script.ipynb`: Configurable runner notebook for the ball tracking pre-annotation pipeline (`tools/preannotate_ball.py`). Allows for use on a non-local kernel (i.e. Colab GPU).

## Related Issues
- Closes #16 