### PR TITLE
fix: align CVAT 1.1 XML schema and resolve import KeyError

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This section serves as a living development log.
 
 ### Recently Completed
 <!-- Latest first. Maximum 10 items. Older entries belong in the git log. -->
+- `fix/cvat-xml-export-fix`: fixes to both `pose/cvat.py` and `ball/cvat.py` modules to fix import errors when importing generated pre-annotation CVAT 1.1 `.xml` files into CVAT.
 - `experiment/preannotation-tool-notebooks`: created `notebooks/tools/preannotate_pose_script.ipynb`, `notebooks/tools/preannotate_ball_script.ipynb` notebooks to provide a way to run `tools/preannotate_pose.py`, `tools/preannotate_ball.py` on a non-local kernel (i.e. Colab GPU).
 - `feat/preannotation-CLI-root-arg`: created `resolvePath` (`utils/io.py`) method for resolving a path from a given `root` and `path` input. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts with addition of `--root` input argument to allow for user to input a custom project root directory rather than the default assumption (`.`).
 - `feat/preannotation-batch-processing`: `getAllVideoPaths` (`utils/video.py`) method for getting video paths from a directory, `batchCVATYOLOPosePreannotation` (`pose/preannotate.py`) method for batch CVAT pose pre-annotation, `batchCVATYOLOBallPreannotation` (`ball/preannotate.py`) method for batch CVAT ball pre-annotation. Refactored `tools/preannotate_pose.py`, `tools/preannotate_ball.py` CLI scripts for batch processing.
@@ -80,7 +81,6 @@ This section serves as a living development log.
 - `chore/docs-restructuring`: `/docs` directory created for any secondary documentation, `research.md` renamed to `RESEARCH.md` and relocated to inside `docs/`. Checked for any internal links that may be affected from restructure, found None.
 - `docs/update-readme-phases`: old "Project Phase" section of README replaced with new "[Pipeline Components](#pipeline-components)" section. Has a more clear direction as to what needs to be built for each component of the project. Updates to `research.md` to replace phase references and remove commitizen section.
 - `experiment/ball-detection-baseline`: evaluated a fine-tuned `yolo11n` and pre-trained `footandball` model for ball tracking on high quality shooting drill footage. Concluded that the fine-tuned `yolo11n` was the better baseline model.
-- `chore/update-build-system`: Integrated GitHub Actions (CI), automated dependency management via pyproject.toml, and established a Branch & PR development protocol.
 
 ---
 

--- a/ball/cvat.py
+++ b/ball/cvat.py
@@ -41,7 +41,9 @@ def toCVATVideoXML(
             continue
         for det in frameData.get("detections", []):
             x1, y1, x2, y2 = det["box"]
-            track = SubElement(root, "track", id=str(trackId), source="auto")
+            track = SubElement(
+                root, "track", id=str(trackId), label="ball", source="auto"
+            )
 
             SubElement(
                 track,

--- a/pose/cvat.py
+++ b/pose/cvat.py
@@ -26,11 +26,11 @@ def _buildMeta(
     SubElement(skelLabel, "name").text = "person"
     SubElement(skelLabel, "type").text = "skeleton"
 
-    sublabels = SubElement(skelLabel, "sublabels")
     for kpName in keypointIndexes:
-        kplabel = SubElement(sublabels, "label")
+        kplabel = SubElement(labels, "label")
         SubElement(kplabel, "name").text = kpName
         SubElement(kplabel, "type").text = "points"
+        SubElement(kplabel, "parent").text = "person"
 
 
 def toCVATVideoXML(
@@ -63,13 +63,19 @@ def toCVATVideoXML(
                 occluded="0",
                 keyframe="1",
             )
-            SubElement(
-                skel,
-                "box",
-                xtl=f"{x1:.2f}",
-                ytl=f"{y1:.2f}",
-                xbr=f"{x2:.2f}",
-                ybr=f"{y2:.2f}",
+            # Mark track as outside on the very next frame
+            # to prevent CVAT interpolating forward
+            outskel = (
+                SubElement(
+                    track,
+                    "skeleton",
+                    frame=str(frameIdx + 1),
+                    outside="1",
+                    occluded="0",
+                    keyframe="1",
+                )
+                if frameIdx + 1 < totalFrames
+                else None
             )
 
             for kpName in keypointIndexes:
@@ -86,17 +92,16 @@ def toCVATVideoXML(
                     occluded="0" if kconf >= confThreshold else "1",
                     keyframe="1",
                 )
-
-            # Mark track as outside on the very next frame
-            # to prevent CVAT interpolating forward
-            if frameIdx + 1 < totalFrames:
-                SubElement(
-                    track,
-                    "skeleton",
-                    frame=str(frameIdx + 1),
-                    outside="1",
-                    occluded="0",
-                    keyframe="1",
-                )
+                # mark keypoint as outside in next frame
+                if outskel is not None:
+                    SubElement(
+                        outskel,
+                        "points",
+                        label=kpName,
+                        points=f"{kx:.2f},{ky:.2f}",
+                        outside="1",
+                        occluded="0" if kconf >= confThreshold else "1",
+                        keyframe="1",
+                    )
             trackId += 1
     return parseString(tostring(root, encoding="unicode")).toprettyxml(indent="  ")

--- a/tests/pose/test_pose_cvat.py
+++ b/tests/pose/test_pose_cvat.py
@@ -52,13 +52,16 @@ def test_toCVATVideoXML_fullCoverage_pose(samplePoseData, poseIndexes):
     )
     root = fromstring(xmlOut)
 
-    # Skeleton and Box existence
-    skeleton = root.find(".//skeleton")
+    # find active skeleton
+    skeleton = root.find(".//skeleton[@outside='0']")
     assert skeleton is not None
-    assert skeleton.find("box") is not None
 
-    # Occlusion
-    pts = root.findall(".//points")
+    # check for termination skeleton
+    outskeleton = root.find(".//skeleton[@outside='1']")
+    assert outskeleton is not None
+
+    # occlusion Check on the active frame
+    pts = skeleton.findall("points")
     rightAnkle = next(p for p in pts if p.get("label") == "right_ankle")
     assert rightAnkle.get("occluded") == "1"
 
@@ -72,17 +75,16 @@ def test_toCVATVideoXML_handlesMissingAndExtraKeypoints(
         keypointIndexes=poseIndexes,
     )
     root = fromstring(xmlOut)
-    pointsTags = root.findall(".//points")
+
+    # Target only the active skeleton for point counting
+    activeSkel = root.find(".//skeleton[@outside='0']")
+    pointsTags = activeSkel.findall("points")
     pointLabels = [p.get("label") for p in pointsTags]
 
-    # should contain left_ankle, but NOT right_ankle
+    # assertions for the active frame
     assert "left_ankle" in pointLabels
     assert "right_ankle" not in pointLabels
-
-    # left_knee should not be in point labels, even though it is in the pose data
     assert "left_knee" not in pointLabels
-
-    # only expect one tag (left_ankle)
     assert len(pointsTags) == 1
 
 


### PR DESCRIPTION
corrects schema mismatches in the XML generation logic for both pose and ball detections. These discrepancies were causing the CVAT 1.1 Video parser to fail with a `KeyError: 'label'` during import.

## Changes
**Module Logic**
- `ball/cvat.py`:
    - Added the missing `label="ball"` attribute to the `<track>` tag, satisfying the parser's requirement for explicit label identification.
- `pose/cvat.py`:
    - **Meta Refactor**: Updated `_buildMeta` to use a flat label structure with `<parent>` tags instead of nested `<sublabels>`, aligning with how CVAT stores skeleton definitions.
    - **Schema Correction**: Removed the `<box>` tag from inside the `<skeleton>` block, which was the primary trigger for the `KeyError`.
    - **Track Termination**: Implemented explicit `outside="1"` termination frames for every skeleton detection. This resolves the "ghosting" issue where poses accumulated across the entire video timeline.
**Tests**
- `tests/pose/test_pose_cvat.py`:
    - Updated `test_toCVATVideoXML_fullCoverage_pose` to remove the box existence assertion.
    - Refactored `test_toCVATVideoXML_handlesMissingAndExtraKeypoints` to target the active skeleton (`outside="0"`) for point counting, ensuring compatibility with the new track termination logic.

## Related Issues
- Closes #20 